### PR TITLE
Fix credits BGM

### DIFF
--- a/Update/&endroll_staff6.txt
+++ b/Update/&endroll_staff6.txt
@@ -5,7 +5,6 @@ void main()
 	PreloadBitmap("tumi_staff_01");
 	//PreloadBitmap("meak_staff_02");
 
-	ModPlayBGM( 0, "ZERO(nonloop)", 56, 0, 1 );
 	DrawScene("black", 2000);
 	Wait( 2500 );
 	//InitializeTiming( 0 );

--- a/Update/_tsum_026a.txt
+++ b/Update/_tsum_026a.txt
@@ -6790,6 +6790,7 @@ void main()
 	DrawScene( "end_2", 1000 );
 	DrawScene( "end_3", 1000 );
 	ModPlayBGM( 0, "song_ps2ed1", 56, 0, 0 );
+	ModPlayBGM( 0, "song_ps2ed1", 56, 0, 1 );
 	SetValidityOfSkipping( FALSE );
 	SetValidityOfInput( FALSE );
 	SetValidityOfUserEffectSpeed( FALSE );


### PR DESCRIPTION
Always play song_ps2ed1 for credits, regardless of BGM setting
 - Previously "Old BGM" setting would play "ZERO(nonloop)"